### PR TITLE
New way to pass ENVIRONMENT VARIABLES to runtime, to control DEBUG ou…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,32 @@
 ## REFERENCES:
 ## (1) Passing environment variable with fallback value to Makefile:
 ##    https://stackoverflow.com/a/70772707/6366150
-##
+## (2) Export environment variables inside "make environment"
+##		https://stackoverflow.com/a/49524393/6366150
+## (3) Uppercase to lowercase and vice versa
+##		https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
+## (4) How do I trim leading and trailing whitespace from each line of some output?
+## 		https://unix.stackexchange.com/a/279222/233927
+## (5) Pytest log levels:
+##		https://docs.pytest.org/en/latest/how-to/logging.html
+############################################################################
 
-DEBUG := "INFO" ## (1) ## INFO | DEBUG
-BRUTEFORCE := "false" # true | false
+## (1) ## Allowed values: info | warn | error | debug
+LOG_LEVEL ?= info
+## (3) (4)
+LOG_LEVEL :=$(shell echo '${LOG_LEVEL}'| tr '[:lower:]' '[:upper:]'| tr -d '[:blank:]')
+
+## (1) ## Allowed values: true | false
+BRUTEFORCE ?= false
+## (3) (4)
+BRUTEFORCE :=$(shell echo '${BRUTEFORCE}'| tr '[:lower:]' '[:upper:]'| tr -d '[:blank:]')
+
+# DOCKER
+BUILDKIT_PROGRESS=plain
 
 .MAIN: test
 .PHONY: all clean dependencies help list test
+.EXPORT_ALL_VARIABLES: # (2)
 
 help: list
 
@@ -18,7 +37,7 @@ env:
 	@echo "################################################################################"
 	@echo "## Environment: ################################################################"
 	@echo "################################################################################"
-	@printenv
+	@printenv | grep -E "LOG_LEVEL|BRUTEFORCE|BUILDKIT_PROGRESS"
 	@echo "################################################################################"
 
 install: dependencies
@@ -39,7 +58,7 @@ lint: dependencies
 	python3 -m pylint --verbose --recursive yes src/
 
 test: env dependencies
-	BRUTEFORCE=$(BRUTEFORCE) pytest --verbose -o log_cli=true --log-cli-level=$(DEBUG) --full-trace src/
+	pytest --verbose -o log_cli=true --log-cli-level=$(LOG_LEVEL) --full-trace src/
 
 coverage: dependencies
 	coverage run -m pytest --verbose src/
@@ -57,13 +76,13 @@ clean:
 	find . -path "*/*.pyo" -delete -print
 	find . -path "*/__pycache__" -type d -print -exec rm -r {} ';'
 
-docker/build:
-	BUILDKIT_PROGRESS=plain docker-compose --profile testing build
+docker/compose-build: env
+	docker-compose --profile testing build
 
-docker/rebuild:
-	BUILDKIT_PROGRESS=plain docker-compose --profile testing build --no-cache
+docker/compose-rebuild: env
+	docker-compose --profile testing build --no-cache
 
 docker/compose-run: docker/build
-	docker-compose --profile testing run --rm projecteuler-py make test -e DEBUG=$(DEBUG) -e BRUTEFORCE=$(BRUTEFORCE)
+	docker-compose --profile testing run --rm projecteuler-py make test
 
 all: lint coverage


### PR DESCRIPTION
…tput and enable/disable BRUTEFORCE test, with fallback values.

REFERENCES:
 * Define a Makefile variable using a ENV variable or a default value https://stackoverflow.com/a/24263397/6366150
 * Docker compose .env default with fallback https://stackoverflow.com/a/70772707/6366150
 * Export environment variables inside "make environment" https://stackoverflow.com/a/49524393/6366150
 * Uppercase to lowercase and vice versa https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
 * How do I trim leading and trailing whitespace from each line of some output? https://unix.stackexchange.com/a/279222/233927