### PR TITLE
New way to pass ENVIRONMENT VARIABLES to runtime, to control DEBUG ou…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install -r requirements.txt
 
 FROM builder as testing
 
-ENV DEBUG=INFO
+ENV LOG_LEVEL=INFO
 ENV BRUTEFORCE=false
 
 RUN adduser -D worker

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ docker/compose-build: env
 docker/compose-rebuild: env
 	docker-compose --profile testing build --no-cache
 
-docker/compose-run: docker/build
+docker/compose-run: docker/compose-build
 	docker-compose --profile testing run --rm projecteuler-py make test
 
 all: lint coverage

--- a/README.md
+++ b/README.md
@@ -52,14 +52,21 @@ Unit test has test cases and input data to solve the problem.
 Run all tests:
 
 ```
-python3 -m unittest discover -s src -p '*_test.py' --verbose
-python3 -m coverage report
+pytest --verbose -o log_cli=true --log-cli-level=INFO --full-trace src/
 ```
 
-Or using make:
+### Testing with full logs
+
+Run all tests with debug outputs:
 
 ```
-make test coverage
+pytest --verbose -o log_cli=true --log-cli-level=DEBUG --full-trace src/
+```
+
+## Testing using make
+
+```
+make test
 ```
 
 ### Enable all large BRUTEFORCE tests
@@ -74,16 +81,14 @@ make test -e BRUTEFORCE=true
 
 
 ```
-make test -e DEBUG=DEBUG
+make test -e LOG_LEVEL=debug
 ```
 
 ### Enable all large BRUTEFORCE tests and all DEBUG outputs
 
-
 ```
-make test -e DEBUG=DEBUG -e BRUTEFORCE=true
+make test -e LOG_LEVEL=debug -e BRUTEFORCE=true
 ```
-
 
 # Running with Docker 🐳
 
@@ -101,15 +106,15 @@ docker-compose run --rm projecteuler-py make test coverage
 
 ## Enable BRUTEFORCE tests with full DEBUG output
 
-With docker-compose
+With docker-compose:
 
 ```
-docker-compose --profile testing run --rm projecteuler-py make test -e DEBUG=DEBUG -e BRUTEFORCE=true
+docker-compose --profile testing run --rm projecteuler-py make test -e LOG_LEVEL=debug -e BRUTEFORCE=true
 ```
 
 Using make:
 ```
-make docker/compose-run -e DEBUG=DEBUG -e BRUTEFORCE=true
+make docker/compose-run -e LOG_LEVEL=DEBUG -e BRUTEFORCE=true
 ```
 
 ## Build and run a development image
@@ -122,6 +127,8 @@ Dependencies should be installed to run (not present in this target) so, you mus
 # install dependencies using docker runtime and store them in host directory
 docker-compose build projecteuler-py-dev
 docker-compose run --rm projecteuler-py-dev make dependencies
+docker-compose run --rm projecteuler-py-dev make test
+
 ```
 
 # About development

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       context: .
       target: testing
     environment:
-      DEBUG: ${DEBUG:-INFO} ## (1) ## INFO | DEBUG
+      LOG_LEVEL: ${LOG_LEVEL:-INFO} ## (1) ## INFO | DEBUG
       BRUTEFORCE: ${BRUTEFORCE:-false} ## (1) ## true | false
     volumes:
       - ./coverage:/app/coverage
@@ -17,7 +17,7 @@ services:
       context: .
       target: development
     environment:
-      DEBUG: ${DEBUG:-INFO}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
       BRUTEFORCE: ${BRUTEFORCE:-false} ## (1) ## true | false
     volumes:
       - ./:/app


### PR DESCRIPTION
…tput and enable/disable BRUTEFORCE test, with fallback values.

REFERENCES:
 * Define a Makefile variable using a ENV variable or a default value https://stackoverflow.com/a/24263397/6366150
 * Docker compose .env default with fallback https://stackoverflow.com/a/70772707/6366150
 * Export environment variables inside "make environment" https://stackoverflow.com/a/49524393/6366150
 * Uppercase to lowercase and vice versa https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
 * How do I trim leading and trailing whitespace from each line of some output? https://unix.stackexchange.com/a/279222/233927